### PR TITLE
fix spotlight alpha

### DIFF
--- a/R/sticker.R
+++ b/R/sticker.R
@@ -74,7 +74,7 @@ hexagon <- function(size=1.2, fill="#1881C2", color="#87B13F") {
 
 ##' @importFrom grDevices rgb
 ##' @author Johannes Rainer with modification from Guangchuang Yu
-whiteTrans <- function(n, alpha = 0.4) {
+whiteTrans <- function(alpha = 0.4) {
     function(n) {
         rgb(red = rep(1, n), green = rep(1, n), blue = rep(1, n),
             alpha = seq(0, alpha, length.out = n))


### PR DESCRIPTION
Currently `l_alpha` is ignored because `spotlight` calls `whiteTrans(alpha)` without explicitly naming the `alpha` argument. So the first argument, namely `n` is used. In fact the argument `n` in `whiteTrans` is not needed. This PR removes the `n` argument. That fixes the evaluation of `l_alpha`.