### PR TITLE
try adding font from google if not found

### DIFF
--- a/R/sticker.R
+++ b/R/sticker.R
@@ -141,6 +141,8 @@ load_font <- function(family) {
     if (any(i)) {
         font_add(family, fonts[which(i)[1]])
         showtext_auto()
+    } else {
+        sysfonts::font_add_google(name = family, family = family)
     }
     return(family)
 }


### PR DESCRIPTION
maybe I'm missing something, but it seems like the `load_font` function currently only looks for families provided by the `hexSticker` package.  I added a fallback -- see if you can download it from google via `sysfonts::font_add_google`